### PR TITLE
remove the local package to remove the broken world issue

### DIFF
--- a/images/sdk/configs/latest.apko.yaml
+++ b/images/sdk/configs/latest.apko.yaml
@@ -3,7 +3,6 @@ contents:
     - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   repositories:
     - https://packages.wolfi.dev/os
-    - /github/workspace/packages
   packages:
     - ca-certificates-bundle
     - wolfi-baselayout

--- a/images/wolfictl/configs/latest.apko.yaml
+++ b/images/wolfictl/configs/latest.apko.yaml
@@ -3,7 +3,6 @@ contents:
     - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   repositories:
     - https://packages.wolfi.dev/os
-    - /github/workspace/packages
   packages:
     - ca-certificates-bundle
     - wolfi-baselayout


### PR DESCRIPTION
Signed-off-by: James Strong <james.strong@chainguard.dev>

remove this issue. 

````
[sdk] ❯ apk add bind-tools 
fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
WARNING: Ignoring /github/workspace/packages: No such file or directory
WARNING: The repository tag for world dependency 'sdk@local' does not exist
ERROR: Not committing changes due to missing repository tags. Use --force-broken-world to override.
````

````
[sdk] ❯ cat /etc/apk/repositories 
https://packages.wolfi.dev/os
@local /github/workspace/packages[sdk] ❯
````
