### PR TITLE
wolfictl: require glibc at runtime

### DIFF
--- a/images/wolfictl/configs/latest.melange.yaml
+++ b/images/wolfictl/configs/latest.melange.yaml
@@ -13,6 +13,7 @@ package:
   dependencies:
     runtime:
       - git
+      - glibc
 
 environment:
   contents:


### PR DESCRIPTION
Related to https://github.com/wolfi-dev/wolfictl/pull/44

`build-base` already provides `gcc` at build-time, `glibc` is needed for graphviz usage at runtime.

Signed-off-by: Jason Hall <jason@chainguard.dev>