### PR TITLE
Update latest.apko.yaml

### DIFF
--- a/images/wolfictl/configs/latest.apko.yaml
+++ b/images/wolfictl/configs/latest.apko.yaml
@@ -12,6 +12,7 @@ contents:
     - busybox
     - gitsign
     - make
+    - graphviz
 
 entrypoint:
   command: /usr/bin/wolfictl


### PR DESCRIPTION
https://github.com/wolfi-dev/wolfictl/pull/174 removes SVG generation from wolfictl, and offloads that to graphviz, which should be available in the image.