### PR TITLE
Add grype to sdk image

### DIFF
--- a/images/sdk/configs/latest.apko.yaml
+++ b/images/sdk/configs/latest.apko.yaml
@@ -7,6 +7,7 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - sdk
+    - grype
 entrypoint:
   command: /usr/bin/sdk
 


### PR DESCRIPTION
It's nice to be able to `grype package/arch/thing-i-just-built.apk` from directly inside the dev container.