### PR TITLE
move musl-dynamic and gcc-musl to this repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: chainguard-images/images
           modified-files: ${{ steps.files.outputs.all }}
-      
+
       # For manual builds, build only the image requested
       - id: generate-matrix-manual
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.only != '' }}

--- a/images/gcc-musl/DEVELOPMENT.md
+++ b/images/gcc-musl/DEVELOPMENT.md
@@ -1,0 +1,27 @@
+# gcc-musl Development
+
+This doc covers building the gcc-musl image locally with apko, and using it with Docker.
+
+## Building -musl Locally
+
+First build the image first using apko:
+```
+apko build apko.yaml gcc-musl:devel gcc-musl.tar
+```
+
+Next, load the image from the tarball:
+```
+docker load < gcc-musl.tar
+```
+
+Try building something:
+```
+docker run --rm -v "${PWD}:/work" -w /work/examples/hello \
+    gcc-musl:devel main.c -o /work/hello
+```
+
+Finally, try running it:
+```
+docker run --rm -v "${PWD}:/work" --entrypoint /work/hello \
+    gcc-musl:devel
+```

--- a/images/gcc-musl/LICENSE
+++ b/images/gcc-musl/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/images/gcc-musl/README.md
+++ b/images/gcc-musl/README.md
@@ -1,0 +1,67 @@
+<!--monopod:start-->
+# gcc-musl
+| | |
+| - | - |
+| **Status** | stable |
+| **OCI Reference** | `cgr.dev/chainguard/gcc-musl` |
+| **Variants/Tags** | ![](https://storage.googleapis.com/chainguard-images-build-outputs/summary/gcc-musl.svg) |
+
+*[Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Minimal container image for building C applications (which do not require glibc).
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/gcc-musl:latest
+```
+
+## Usage
+
+To build the C application in [examples/hello/main.c](https://github.com/chainguard-images/images/blob/main/images/gcc-glibc/examples/hello/main.c):
+
+```
+$ docker run --rm -v "${PWD}:/work" cgr.dev/chainguard/gcc-musl examples/hello/main.c -o hello
+```
+
+This will write a Linux binary to `./hello`. If you're on Linux and have the musl library, you
+should be able to run it directly. Otherwise you can run it in a container e.g:
+
+```
+$ docker run --rm -v "$PWD/hello:/hello" cgr.dev/chainguard/musl-dynamic /hello
+Hello World!
+```
+
+We can also do this all in a multi-stage Dockerfile e.g:
+
+```Dockerfile
+FROM cgr.dev/chainguard/gcc-musl as build
+
+COPY hello.c /work/hello.c
+RUN cc hello.c -o hello
+
+FROM cgr.dev/chainguard/musl-dynamic
+
+COPY --from=build /work/hello /hello
+CMD ["/hello"]
+```
+
+And we can also compile statically to be used in environments without musl:
+
+
+```Dockerfile
+FROM cgr.dev/chainguard/gcc-musl as build
+
+COPY hello.c /work/hello.c
+RUN cc --static hello.c -o hello
+
+FROM cgr.dev/chainguard/static
+
+COPY --from=build /work/hello /hello
+CMD ["/hello"]
+```

--- a/images/gcc-musl/configs/latest.apko.yaml
+++ b/images/gcc-musl/configs/latest.apko.yaml
@@ -1,0 +1,21 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+  packages:
+    - ca-certificates-bundle
+    - alpine-baselayout-data
+    - alpine-release
+    - gcc
+    - musl-dev
+    - busybox
+
+paths:
+  - path: /work
+    type: directory
+    permissions: 0o777
+
+work-dir: /work
+
+entrypoint:
+  command: /usr/bin/gcc
+cmd: --help

--- a/images/gcc-musl/examples/hello/main.c
+++ b/images/gcc-musl/examples/hello/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello World!\n");
+    return 0;
+}

--- a/images/gcc-musl/image.yaml
+++ b/images/gcc-musl/image.yaml
@@ -1,0 +1,5 @@
+versions:
+  - apko:
+      config: configs/latest.apko.yaml
+      extractTagsFrom:
+        package: gcc

--- a/images/gcc-musl/tests/01-version.sh
+++ b/images/gcc-musl/tests/01-version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+if [[ "${IMAGE_NAME}" == "" ]]; then
+    echo "Must set IMAGE_NAME environment variable. Exiting."
+    exit 1
+fi
+
+docker run --rm $IMAGE_NAME --version

--- a/images/musl-dynamic/README.md
+++ b/images/musl-dynamic/README.md
@@ -1,0 +1,31 @@
+<!--monopod:start-->
+# musl-dynamic
+| | |
+| - | - |
+| **Status** | stable |
+| **OCI Reference** | `cgr.dev/chainguard/musl-dynamic` |
+| **Variants/Tags** | ![](https://storage.googleapis.com/chainguard-images-build-outputs/summary/musl-dynamic.svg) |
+
+*[Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Base image with just enough files to run static binaries!
+
+This image is meant to be used as a base image only, and is otherwise useless. It contains the `alpine-baselayout-data` package from Alpine, which is just a set of data files needed to support glibc and musl static binaries at runtime.
+
+This image can be used with `ko build`, `docker`, etc, but is only suitable for running static binaries.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/musl-dynamic:latest
+```
+# Usage
+
+See the [examples/](https://github.com/chainguard-images/images/tree/main/images/musl-dynamic/examples) directory for
+an example C program and associated Dockerfile
+that can be used with this image.

--- a/images/musl-dynamic/configs/latest.apko.yaml
+++ b/images/musl-dynamic/configs/latest.apko.yaml
@@ -1,0 +1,8 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+  packages:
+    - alpine-baselayout-data
+    - alpine-release
+    - ca-certificates-bundle
+    - musl

--- a/images/musl-dynamic/examples/Dockerfile.c
+++ b/images/musl-dynamic/examples/Dockerfile.c
@@ -1,0 +1,11 @@
+ARG BASE=cgr.dev/chainguard/musl-dynamic
+
+FROM cgr.dev/chainguard/gcc-musl as build
+
+COPY hello.c /work/hello.c
+RUN cc hello.c -o hello
+
+FROM $BASE
+
+COPY --from=build /work/hello /hello
+CMD ["/hello"]

--- a/images/musl-dynamic/examples/hello.c
+++ b/images/musl-dynamic/examples/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() { 
+    printf("Hello!\n"); 
+    return 0;
+}

--- a/images/musl-dynamic/image.yaml
+++ b/images/musl-dynamic/image.yaml
@@ -1,0 +1,5 @@
+versions:
+  - apko:
+      config: configs/latest.apko.yaml
+      extractTagsFrom:
+        package: musl

--- a/images/musl-dynamic/tests/01-dockerfile-c-build.sh
+++ b/images/musl-dynamic/tests/01-dockerfile-c-build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+if [[ "${IMAGE_NAME}" == "" ]]; then
+    echo "Must set IMAGE_NAME environment variable. Exiting."
+    exit 1
+fi
+
+cd "$(dirname ${BASH_SOURCE[0]})/.."
+
+docker build --build-arg BASE="${IMAGE_NAME}" --tag smoke-test --file examples/Dockerfile.c examples
+docker run --rm smoke-test


### PR DESCRIPTION
These images are based on Alpine packages, and shouldn't be included in Chainguard Images, which are typically Wolfi-based.