### PR TITLE
add wolfi image

### DIFF
--- a/images/wolfi/README.md
+++ b/images/wolfi/README.md
@@ -1,0 +1,5 @@
+Wolfi base image built with [apko](https://github.com/chainguard-dev/apko). Uses packages from the [Wolfi un-distribution](https://wolfi.dev/).
+
+```
+docker run ghcr.io/wolfi-dev/wolfi echo "hello"
+```

--- a/images/wolfi/configs/latest.apko.yaml
+++ b/images/wolfi/configs/latest.apko.yaml
@@ -1,0 +1,6 @@
+contents:
+  packages:
+    - wolfi-base
+
+cmd: /bin/sh -l
+

--- a/images/wolfi/main.tf
+++ b/images/wolfi/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+provider "apko" {
+  extra_repositories = ["https://packages.wolfi.dev/os"]
+  extra_keyring      = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
+  default_archs      = ["arm64", "amd64"]
+}
+
+module "latest" {
+  source = "../../tflib/publisher"
+
+  target_repository = var.target_repository
+  config            = file("${path.module}/configs/latest.apko.yaml")
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "version-tags" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}

--- a/images/wolfi/tests/01-runs.sh
+++ b/images/wolfi/tests/01-runs.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# Running with and without a command doesn't error
+docker run --rm $IMAGE_NAME
+docker run --rm $IMAGE_NAME apk --version | grep "apk-tools .*"
+
+# The image runs as root by default.
+docker run --rm --entrypoint '' $IMAGE_NAME whoami | grep "^root$"
+
+# The image contains busybox.
+docker run --rm $IMAGE_NAME busybox | grep "^BusyBox .* multi-call binary."
+
+# The image can be used as a base image.
+cat <<EOF | docker build -t version -
+FROM ${IMAGE_NAME}
+RUN apk --version
+ENTRYPOINT ["apk"]
+EOF
+docker run version --version | grep "^apk-tools "
+
+# The image can be used as a base image with a custom entrypoint.
+cat <<EOF | docker build -t version-entrypoint -
+FROM ${IMAGE_NAME}
+RUN apk --version
+RUN mkdir -p /usr/local/bin && \
+   echo '#!/bin/sh' > /usr/local/bin/hello && \
+   echo 'apk --version' >> /usr/local/bin/hello && \
+   chmod +x /usr/local/bin/hello
+ENTRYPOINT ["hello"]
+EOF
+docker run version-entrypoint | grep "^apk-tools "

--- a/images/wolfi/tests/main.tf
+++ b/images/wolfi/tests/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "runs" {
+  digest = var.digest
+  script = "${path.module}/01-runs.sh"
+}


### PR DESCRIPTION
This builds an image at `ghcr.io/wolfi-dev/wolfi` that's equivalent to `cgr.dev/chainguard/wolfi-base`, but defined in this repo, under the wolfi org.

We seemingly can't use apko's `include:` feature to reference the config in the chainguard-images repo, since the TF provider doesn't seem to support that well today. And anyway, the config is small, and one could argue just being a symlink to the Chainguard image defeats the purpose anyway. So this is purely a copy of that config, adapted to this repo's conventions.