### PR TITLE
wolfictl: add git as dependency

### DIFF
--- a/images/wolfictl/configs/latest.apko.yaml
+++ b/images/wolfictl/configs/latest.apko.yaml
@@ -9,6 +9,7 @@ contents:
     - gitsign
     - make
     - graphviz
+    - git
 
 entrypoint:
   command: /usr/bin/wolfictl


### PR DESCRIPTION
This is needed to allow wolfictl to generate update PRs.  The previous internal `wolfictl` package had `git` as a dependency, the Wolfi one does not.