### PR TITLE
fix musl images

### DIFF
--- a/images/gcc-musl/README.md
+++ b/images/gcc-musl/README.md
@@ -1,16 +1,3 @@
-<!--monopod:start-->
-# gcc-musl
-| | |
-| - | - |
-| **Status** | stable |
-| **OCI Reference** | `cgr.dev/chainguard/gcc-musl` |
-| **Variants/Tags** | ![](https://storage.googleapis.com/chainguard-images-build-outputs/summary/gcc-musl.svg) |
-
-*[Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
-
----
-<!--monopod:end-->
-
 Minimal container image for building C applications (which do not require glibc).
 
 ## Get It!
@@ -18,7 +5,7 @@ Minimal container image for building C applications (which do not require glibc)
 The image is available on `cgr.dev`:
 
 ```
-docker pull cgr.dev/chainguard/gcc-musl:latest
+docker pull ghcr.io/wolfi-dev/gcc-musl:latest
 ```
 
 ## Usage
@@ -26,26 +13,26 @@ docker pull cgr.dev/chainguard/gcc-musl:latest
 To build the C application in [examples/hello/main.c](https://github.com/chainguard-images/images/blob/main/images/gcc-glibc/examples/hello/main.c):
 
 ```
-$ docker run --rm -v "${PWD}:/work" cgr.dev/chainguard/gcc-musl examples/hello/main.c -o hello
+$ docker run --rm -v "${PWD}:/work" ghcr.io/wolfi-dev/gcc-musl examples/hello/main.c -o hello
 ```
 
 This will write a Linux binary to `./hello`. If you're on Linux and have the musl library, you
 should be able to run it directly. Otherwise you can run it in a container e.g:
 
 ```
-$ docker run --rm -v "$PWD/hello:/hello" cgr.dev/chainguard/musl-dynamic /hello
+$ docker run --rm -v "$PWD/hello:/hello" ghcr.io/wolfi-dev/musl-dynamic /hello
 Hello World!
 ```
 
 We can also do this all in a multi-stage Dockerfile e.g:
 
 ```Dockerfile
-FROM cgr.dev/chainguard/gcc-musl as build
+FROM ghcr.io/wolfi-dev/gcc-musl as build
 
 COPY hello.c /work/hello.c
 RUN cc hello.c -o hello
 
-FROM cgr.dev/chainguard/musl-dynamic
+FROM ghcr.io/wolfi-dev/musl-dynamic
 
 COPY --from=build /work/hello /hello
 CMD ["/hello"]
@@ -55,7 +42,7 @@ And we can also compile statically to be used in environments without musl:
 
 
 ```Dockerfile
-FROM cgr.dev/chainguard/gcc-musl as build
+FROM ghcr.io/wolfi-dev/gcc-musl as build
 
 COPY hello.c /work/hello.c
 RUN cc --static hello.c -o hello

--- a/images/musl-dynamic/README.md
+++ b/images/musl-dynamic/README.md
@@ -1,28 +1,5 @@
-<!--monopod:start-->
-# musl-dynamic
-| | |
-| - | - |
-| **Status** | stable |
-| **OCI Reference** | `cgr.dev/chainguard/musl-dynamic` |
-| **Variants/Tags** | ![](https://storage.googleapis.com/chainguard-images-build-outputs/summary/musl-dynamic.svg) |
-
-*[Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
-
----
-<!--monopod:end-->
-
-Base image with just enough files to run static binaries!
-
-This image is meant to be used as a base image only, and is otherwise useless. It contains the `alpine-baselayout-data` package from Alpine, which is just a set of data files needed to support glibc and musl static binaries at runtime.
-
-This image can be used with `ko build`, `docker`, etc, but is only suitable for running static binaries.
-
-## Get It!
-
-The image is available on `cgr.dev`:
-
 ```
-docker pull cgr.dev/chainguard/musl-dynamic:latest
+docker pull ghcr.io/wolfi-dev/musl-dynamic:latest
 ```
 # Usage
 

--- a/images/musl-dynamic/examples/Dockerfile.c
+++ b/images/musl-dynamic/examples/Dockerfile.c
@@ -1,6 +1,6 @@
-ARG BASE=cgr.dev/chainguard/musl-dynamic
+ARG BASE=ghcr.io/wolfi-dev/musl-dynamic
 
-FROM cgr.dev/chainguard/gcc-musl as build
+FROM ghcr.io/wolfi-dev/gcc-musl as build
 
 COPY hello.c /work/hello.c
 RUN cc hello.c -o hello


### PR DESCRIPTION
musl-dynamic image tests fail with:

```
│  > [internal] load metadata for cgr.dev/chainguard/gcc-musl:latest:
│ ------
│ Dockerfile.c:3
│ --------------------
│    1 |     ARG BASE=cgr.dev/chainguard/musl-dynamic
│    2 |     
│    3 | >>> FROM cgr.dev/chainguard/gcc-musl as build
│    4 |     
│    5 |     COPY hello.c /work/hello.c
│ --------------------
│ ERROR: failed to solve: cgr.dev/chainguard/gcc-musl:
│ cgr.dev/chainguard/gcc-musl:latest: not found

```

I also noticed some places where we still mention cgr.dev/chainguard where it should be ghcr.io/wolfi-dev/...