### PR TITLE
Update latest.melange.yaml

### DIFF
--- a/images/sdk/configs/latest.melange.yaml
+++ b/images/sdk/configs/latest.melange.yaml
@@ -3,18 +3,12 @@ package:
   version: 0.0.1
   epoch: 0
   description: Development tools for melange and apko
-  target-architecture:
-    - all
   copyright:
-    - paths:
-      - "*"
-      attestation: TODO
-      license: Apache-2.0
+    - license: Apache-2.0
   dependencies:
     runtime:
       - apk-tools
       - make
-      - go
       - git
       - curl
       - bash

--- a/images/sdk/tests/01-has-all-tools.sh
+++ b/images/sdk/tests/01-has-all-tools.sh
@@ -11,7 +11,6 @@ fi
 docker run --rm --entrypoint bash "${IMAGE_NAME}" -xc \
     'which goimports &&
      tree --version &&
-     go version &&
      make --version &&
      curl --version &&
      git version &&


### PR DESCRIPTION
Melange doesn't have a run-time dependency on go.