### PR TITLE
sdk/tests: check all packages are up to date

### DIFF
--- a/images/sdk/tests/01-has-all-tools.sh
+++ b/images/sdk/tests/01-has-all-tools.sh
@@ -20,3 +20,10 @@ docker run --rm --entrypoint bash "${IMAGE_NAME}" -xc \
      melange version &&
      apko version &&
      wolfictl version'
+
+# Check that everything is up to date
+# Freshly minted image, should be fully up to date, this however will
+# catch any package renames/provides that apko resolved using out of
+# date packages, due to packaging mistakes or ongoing transitions
+docker run --rm --entrypoint bash "${IMAGE_NAME}" -xc \
+     'apk update; apk upgrade --all --latest || true'


### PR DESCRIPTION
Check that everything is up to date

Freshly minted image, should be fully up to date, this however will catch any package renames/provides that apko resolved using out of date packages, due to packaging mistakes or ongoing transitions

Non-fatal for now

Related: https://github.com/wolfi-dev/os/pull/14692

CC @smoser 