### PR TITLE
Bump download upload artifact together

### DIFF
--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -73,14 +73,14 @@ jobs:
       # Fetch the build stages back down
       - name: 'Download package archives'
         if: inputs.melange-config != ''
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.image }}-aarch64
           path: ./packages
 
       - name: 'Download package archives'
         if: inputs.melange-config != ''
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.image }}-x86_64
           path: ./packages

--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -42,7 +42,7 @@ jobs:
           archs: ${{ matrix.arch }}
 
       - name: 'Upload built packages archive to Github Artifacts'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.image }}-${{ matrix.arch }}
           path: ./packages


### PR DESCRIPTION
seems like one cannot bump one without the other; hence both dependabot PRs are failing

Related: https://github.com/wolfi-dev/tools/pull/82 https://github.com/wolfi-dev/tools/pull/83