### PR TITLE
Revert "wolfictl: track wolfictl releases instead of building from git HEAD"

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -42,6 +42,7 @@ jobs:
     uses: ./.github/workflows/.build.yaml
     with:
       image: wolfictl
+      melange-config: configs/latest.melange.yaml
 
   static-alpine:
     uses: ./.github/workflows/.build.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,7 @@ jobs:
     uses: ./.github/workflows/.build.yaml
     with:
       image: wolfictl
+      melange-config: configs/latest.melange.yaml
       registry: ghcr.io/wolfi-dev/wolfictl
 
   static-alpibe:

--- a/images/wolfictl/configs/latest.apko.yaml
+++ b/images/wolfictl/configs/latest.apko.yaml
@@ -2,7 +2,7 @@ contents:
   packages:
     - ca-certificates-bundle
     - wolfi-baselayout
-    - wolfictl
+    - wolfictl-head
     - coreutils
     - bash
     - busybox

--- a/images/wolfictl/configs/latest.melange.yaml
+++ b/images/wolfictl/configs/latest.melange.yaml
@@ -1,5 +1,5 @@
 package:
-  name: wolfictl
+  name: wolfictl-head
   version: 0.0.1
   epoch: 1
   description: A CLI used to work with the Wolfi OSS project

--- a/images/wolfictl/configs/latest.melange.yaml
+++ b/images/wolfictl/configs/latest.melange.yaml
@@ -1,0 +1,37 @@
+package:
+  name: wolfictl
+  version: 0.0.1
+  epoch: 1
+  description: A CLI used to work with the Wolfi OSS project
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: Apache-2.0
+  dependencies:
+    runtime:
+      - git
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - ca-certificates-bundle
+      - build-base
+      - busybox
+      - go
+      - git
+
+pipeline:
+  - runs: |
+      set -x
+      git clone https://github.com/wolfi-dev/wolfictl.git
+      (cd wolfictl && make wolfictl)
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      mv wolfictl/wolfictl "${{targets.destdir}}/usr/bin/wolfictl"
+      rm -rf wolfictl/

--- a/images/wolfictl/main.tf
+++ b/images/wolfictl/main.tf
@@ -10,8 +10,8 @@ variable "target_repository" {
 }
 
 provider "apko" {
-  extra_repositories = ["https://packages.wolfi.dev/os"]
-  extra_keyring      = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
+  extra_repositories = ["https://packages.wolfi.dev/os", "${path.module}/../../packages"]
+  extra_keyring      = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub", "${path.module}/../../melange.rsa.pub"]
   default_archs      = ["arm64", "amd64"]
 }
 


### PR DESCRIPTION
This reverts commit 3b391f5b18f5b624d3dd9af12d12c6a42f1529e5.

Rationale:

Consistency. All the other tools in the sdk image are built from HEAD and only require cutting a tolls release and updating digests. Contrast that with `wolfictl`, which requires cutting a wolfictl release, bumping it in wolfi-dev/os, waiting for the build infrastructure to publish the APK, then cutting a tools release, then updating digests. I didn't realize that `wolfictl` had a different release lifecycle for the sdk image from all the other tools, so I expected some changes to be present in our postsubmit that just weren't, which is leading to a lot of toil.

Convenience. See above. It takes a long time to actually land a change to our build infrastructure if we have to roundtrip through wolfi first.

Circular Dependencies. If something is broken with wolfi's builds because there's a bug in `wolfictl`, we won't be able to fix it because updating the sdk image requires releasing a new `wolfictl` APK, which requires wolfi's build infrastructure to work.