### PR TITLE
sdk: pin bincapz to 0.10 to avoid large Ns in quadratic behavior

### DIFF
--- a/images/sdk/configs/latest.melange.yaml
+++ b/images/sdk/configs/latest.melange.yaml
@@ -23,7 +23,7 @@ package:
       - tree
       - alpine-keys
       - jq
-      - bincapz
+      - bincapz~0.10 # TODO: use latest bincapz
 
 environment:
   contents:


### PR DESCRIPTION
bincapz 0.11.0 started discovering archives in directories, which causes our bincapz diffs to become very slow. The current theory is that package matching is quadratic, and that finding these archives leads this to take a very long time.