### PR TITLE
sdk: during wolfictl build gobump melange

### DIFF
--- a/images/sdk/configs/latest.melange.yaml
+++ b/images/sdk/configs/latest.melange.yaml
@@ -36,6 +36,7 @@ environment:
       - build-base
       - busybox
       - go
+      - gobump
       - git
 
 pipeline:
@@ -64,6 +65,7 @@ pipeline:
 
       # wolfictl
       git clone https://github.com/wolfi-dev/wolfictl.git
+      (cd wolfictl && gobump --packages "chainguard.dev/melange@latest")
       (cd wolfictl && make wolfictl install)
 
       #yam


### PR DESCRIPTION
wolfictl & melange are both built from git tip, however the former vendors the latter. Thus there can be disrepancy between the two melanges as used directly or via wolfictl. To resolve this discrepancy, always gobump melange in wolfictl prior to the build.

This will ensure SDK image is always internally consistent w.r.t. melange capabilities.