### PR TITLE
Rename bincapz to malcontent

### DIFF
--- a/images/sdk/configs/latest.melange.yaml
+++ b/images/sdk/configs/latest.melange.yaml
@@ -7,7 +7,7 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: Apache-2.0
   dependencies:
@@ -23,7 +23,7 @@ package:
       - tree
       - alpine-keys
       - jq
-      - bincapz
+      - malcontent
 
 environment:
   contents:


### PR DESCRIPTION
`bincapz` is now `malcontent`

Depends on: https://github.com/wolfi-dev/os/pull/29171