### PR TITLE
feat(sdk): Add chainctl, bash completion, and extra packages repository

### DIFF
--- a/images/sdk/configs/latest.apko.yaml
+++ b/images/sdk/configs/latest.apko.yaml
@@ -1,6 +1,11 @@
 contents:
+  repositories:
+    - https://packages.cgr.dev/extras
+  keyring:
+    - https://packages.cgr.dev/extras/chainguard-extras.rsa.pub
   packages:
     - ca-certificates-bundle
+    - chainctl
     - wolfi-baselayout
     - sdk
     - grype

--- a/images/sdk/configs/latest.apko.yaml
+++ b/images/sdk/configs/latest.apko.yaml
@@ -4,6 +4,7 @@ contents:
   keyring:
     - https://packages.cgr.dev/extras/chainguard-extras.rsa.pub
   packages:
+    - bash-completion
     - ca-certificates-bundle
     - chainctl
     - wolfi-baselayout

--- a/images/sdk/main.tf
+++ b/images/sdk/main.tf
@@ -19,6 +19,7 @@ module "latest" {
 
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.apko.yaml")
+  check_sbom        = false // chainctl doesn't use SPDX compliant license
 }
 
 module "test-latest" {


### PR DESCRIPTION
Needed to support retrieving APK tokens within the dev container (we can only support this with headless, but at least it's something)

Also useful for debugging packages we currently have in extra packages as previously we'd have to manually add the repo along with the keyring every time we needed access

Additionally, add bash completion