### PR TITLE
add volume to oci config for docker to use

### DIFF
--- a/images/sdk/configs/latest.apko.yaml
+++ b/images/sdk/configs/latest.apko.yaml
@@ -25,3 +25,6 @@ environment:
 
 entrypoint:
   command: /usr/bin/sdk
+
+volumes:
+  - "/var/lib/docker"


### PR DESCRIPTION
docker (the runtime) actually parses the oci config for `volumes` to auto-discover which directories to mount.

when running dind,  `/var/lib/docker` is needed for the default snapshotter to work