### PR TITLE
add spdx-tools image

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -40,3 +40,8 @@ jobs:
     uses: ./.github/workflows/.build.yaml
     with:
       image: busybox
+
+  spdx-tools:
+    uses: ./.github/workflows/.build.yaml
+    with:
+      image: spdx-tools

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,3 +56,9 @@ jobs:
     with:
       image: busybox
       registry: ghcr.io/wolfi-dev
+
+  spdx-tools:
+    uses: ./.github/workflows/.build.yaml
+    with:
+      image: spdx-tools
+      registry: ghcr.io/wolfi-dev

--- a/images/spdx-tools/configs/latest.apko.yaml
+++ b/images/spdx-tools/configs/latest.apko.yaml
@@ -1,0 +1,21 @@
+contents:
+  packages:
+    - busybox
+    - spdx-tools-java
+
+environment:
+  LANG: en_US.UTF-8
+  JAVA_HOME: /usr/lib/jvm/default-jvm
+
+accounts:
+  groups:
+  - gid: 65532
+    groupname: nonroot
+  users:
+  - uid: 65532
+    gid: 65532
+    username: nonroot
+  run-as: "65532"
+
+entrypoint:
+  command: /usr/bin/tools-java

--- a/images/spdx-tools/main.tf
+++ b/images/spdx-tools/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest" {
+  source  = "chainguard-dev/apko/publisher"
+  version = "0.0.16"
+
+  target_repository = var.target_repository
+  config            = file("${path.module}/configs/latest.apko.yaml")
+  check_sbom        = true
+}
+
+resource "oci_tag" "version-tags" {
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}

--- a/main.tf
+++ b/main.tf
@@ -100,3 +100,8 @@ module "static" {
   target_repository = "${var.target_repository}/static"
   providers         = { apko.alpine = apko.alpine }
 }
+
+module "spdx-tools" {
+  source            = "./images/spdx-tools"
+  target_repository = "${var.target_repository}/spdx-tools"
+}


### PR DESCRIPTION
We depend on cgr.dev/chainguard/spdx-tools in a few places, but it shouldn't stay in the free tier, we should just build our own here in this repo.