### PR TITLE
reinstate apko image

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -10,6 +10,11 @@ jobs:
     with:
       image: alpine-base
 
+  apko:
+    uses: ./.github/workflows/.build.yaml
+    with:
+      image: apko
+
   gcc-musl:
     uses: ./.github/workflows/.build.yaml
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,12 @@ jobs:
       image: alpine-base
       registry: ghcr.io/wolfi-dev
 
+  apko:
+    uses: ./.github/workflows/.build.yaml
+    with:
+      image: apko
+      registry: ghcr.io/wolfi-dev
+
   gcc-musl:
     uses: ./.github/workflows/.build.yaml
     with:

--- a/images/apko/README.md
+++ b/images/apko/README.md
@@ -1,0 +1,11 @@
+# sdk
+
+Development image for [apko](https://github.com/chainguard-dev/apko).
+
+## Get It!
+
+The image is available on `ghcr.io`:
+
+```
+docker pull ghcr.io/wolfi-dev/apko:latest
+```

--- a/images/apko/main.tf
+++ b/images/apko/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest" {
+  source  = "chainguard-dev/apko/publisher"
+  version = "0.0.17"
+
+  target_repository = var.target_repository
+  config = jsonencode({
+    contents = {
+      packages = ["apko"]
+    }
+    entrypoint = {
+      command = "/usr/bin/apko"
+    }
+  })
+  check_sbom = true
+}
+
+data "oci_exec_test" "version" {
+  digest = module.latest.image_ref
+  script = "docker run --rm $${IMAGE_NAME} version"
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [data.oci_exec_test.version]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,11 @@ module "alpine-base" {
   providers         = { apko.alpine = apko.alpine }
 }
 
+module "apko" {
+  source            = "./images/apko"
+  target_repository = "${var.target_repository}/apko"
+}
+
 module "busybox" {
   source            = "./images/busybox"
   target_repository = "${var.target_repository}/busybox"


### PR DESCRIPTION
We need this for https://github.com/chainguard-images/images-private/pull/6620, and we need it to be an image _not_ built from images-private, to avoid a dependency cycle that prevents us from making breaking changes.