### PR TITLE
Add qemu to sdk to support MELANGE_RUNNER=qemu

### DIFF
--- a/images/sdk/configs/latest.apko.yaml
+++ b/images/sdk/configs/latest.apko.yaml
@@ -26,6 +26,7 @@ contents:
     - malcontent
     - melange
     - mount
+    - qemu
     - spdx-tools-java
     - tree
     - wolfi-baselayout


### PR DESCRIPTION
Tested on ubuntu host, having qemu in the sdk allows

    make MELANGE_RUNNER=qemu package/dash