### PR TITLE
remove alpine-keys package

### DIFF
--- a/images/sdk/configs/latest.apko.yaml
+++ b/images/sdk/configs/latest.apko.yaml
@@ -4,7 +4,6 @@ contents:
   keyring:
     - https://packages.cgr.dev/extras/chainguard-extras.rsa.pub
   packages:
-    - alpine-keys
     - apk-tools
     - apko
     - bash


### PR DESCRIPTION
ci is failing https://github.com/wolfi-dev/tools/actions/runs/18115715420/job/51550820490


seems alpine-keys package was dropped here https://github.com/wolfi-dev/os/pull/23736