### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,11 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
   - package-ecosystem: terraform
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3

--- a/.github/workflows/.build.yaml
+++ b/.github/workflows/.build.yaml
@@ -38,17 +38,20 @@ jobs:
       # Auth to GitHub Container Registry (ghcr.io)
       - name: Login to registry
         if: inputs.registry != ''
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -x
-          echo "${{ github.token }}" | docker login \
-            -u "${{ github.repository_owner }}" \
+          echo "$GITHUB_TOKEN" | docker login \
+            -u "$GITHUB_REPOSITORY_OWNER" \
             --password-stdin ghcr.io
 
       # Build and push image using terraform-provider-apko
       - name: Build image with apko/terraform
         env:
           TF_VAR_target_repository: ${{ inputs.registry != '' && inputs.registry || format('localhost:5000/{0}', inputs.image) }}
+          IMAGE: ${{ inputs.image }}
         run: |
           set -x
           terraform init
-          terraform apply -auto-approve -target=module.${{inputs.image}}
+          terraform apply -auto-approve -target="module.${IMAGE}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,62 +8,95 @@ on:
 
 concurrency: release
 
-permissions:
-  contents: read  # Needed to clone the repo
-  id-token: write # Needed to sign images
-  packages: write # Needed to publish images to GHCR
+permissions: {}
 
 jobs:
   alpine-base:
     uses: ./.github/workflows/.build.yaml
+    permissions:
+      contents: read # Clone the repo in the reusable build workflow
+      id-token: write # Keyless image signing via cosign/OIDC
+      packages: write # Publish images to GHCR
     with:
       image: alpine-base
       registry: ghcr.io/wolfi-dev
 
   apko:
     uses: ./.github/workflows/.build.yaml
+    permissions:
+      contents: read # Clone the repo in the reusable build workflow
+      id-token: write # Keyless image signing via cosign/OIDC
+      packages: write # Publish images to GHCR
     with:
       image: apko
       registry: ghcr.io/wolfi-dev
 
   gcc-musl:
     uses: ./.github/workflows/.build.yaml
+    permissions:
+      contents: read # Clone the repo in the reusable build workflow
+      id-token: write # Keyless image signing via cosign/OIDC
+      packages: write # Publish images to GHCR
     with:
       image: gcc-musl
       registry: ghcr.io/wolfi-dev
 
   musl-dynamic:
     uses: ./.github/workflows/.build.yaml
+    permissions:
+      contents: read # Clone the repo in the reusable build workflow
+      id-token: write # Keyless image signing via cosign/OIDC
+      packages: write # Publish images to GHCR
     with:
       image: musl-dynamic
       registry: ghcr.io/wolfi-dev
 
   sdk:
     uses: ./.github/workflows/.build.yaml
+    permissions:
+      contents: read # Clone the repo in the reusable build workflow
+      id-token: write # Keyless image signing via cosign/OIDC
+      packages: write # Publish images to GHCR
     with:
       image: sdk
       registry: ghcr.io/wolfi-dev
 
   static-alpine:
     uses: ./.github/workflows/.build.yaml
+    permissions:
+      contents: read # Clone the repo in the reusable build workflow
+      id-token: write # Keyless image signing via cosign/OIDC
+      packages: write # Publish images to GHCR
     with:
       image: static
       registry: ghcr.io/wolfi-dev
 
   git-alpine:
     uses: ./.github/workflows/.build.yaml
+    permissions:
+      contents: read # Clone the repo in the reusable build workflow
+      id-token: write # Keyless image signing via cosign/OIDC
+      packages: write # Publish images to GHCR
     with:
       image: git
       registry: ghcr.io/wolfi-dev
 
   busybox-alpine:
     uses: ./.github/workflows/.build.yaml
+    permissions:
+      contents: read # Clone the repo in the reusable build workflow
+      id-token: write # Keyless image signing via cosign/OIDC
+      packages: write # Publish images to GHCR
     with:
       image: busybox
       registry: ghcr.io/wolfi-dev
 
   spdx-tools:
     uses: ./.github/workflows/.build.yaml
+    permissions:
+      contents: read # Clone the repo in the reusable build workflow
+      id-token: write # Keyless image signing via cosign/OIDC
+      packages: write # Publish images to GHCR
     with:
       image: spdx-tools
       registry: ghcr.io/wolfi-dev

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
+      - '.github/dependabot.yaml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
+      - '.github/dependabot.yaml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,15 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+rules:
+  # Paired with `cooldown.default-days: 3` in .github/dependabot.yaml.
+  # Pedantic persona's default cooldown threshold is 7 days; lower it to
+  # match the repo's configured cooldown.
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
This PR applies GitHub Actions hardening fixes across the workflows in
`.github/workflows/`, surfaced by static analysis (zizmor).

## What this changes

- **Template-injection fix.** Context expressions interpolated into `run:`
  blocks in the build workflow are hoisted into `env:` and referenced as quoted
  shell variables.
- **Least-privilege permissions** scoped across the workflows.
- **Repo-level zizmor config + dependabot cooldown** disabling cosmetic
  pedantic-only rules and adding a `dependabot-cooldown` threshold, paired with a
  `cooldown.default-days: 3` on the repo's existing `.github/dependabot.yaml`.

## Test plan

- `zizmor .github/` — clean after these changes.
- `actionlint` — workflows still parse with no errors.

Refs: PSEC-923